### PR TITLE
Refactor provider initialization to align with Go idioms

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -177,10 +177,14 @@ func (p *TrendMicroProvider) Functions(ctx context.Context) []func() function.Fu
 	}
 }
 
-func New(version string) func() provider.Provider {
+func New(version string) provider.Provider {
+	return &TrendMicroProvider{
+		version: version,
+	}
+}
+
+func NewFactory(version string) func() provider.Provider {
 	return func() provider.Provider {
-		return &TrendMicroProvider{
-			version: version,
-		}
+		return New(version)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func main() {
 		Debug:   debug,
 	}
 
-	err := providerserver.Serve(context.Background(), provider.New(version), opts)
+	err := providerserver.Serve(context.Background(), provider.NewFactory(version), opts)
 
 	if err != nil {
 		log.Fatal(err.Error())


### PR DESCRIPTION
- Updated the  function to return a  directly, simplifying the function signature in line with Go's conventions.
- Introduced a new  function to provide a factory method, preserving the previous behavior where a provider factory is needed.